### PR TITLE
Add sandbag option to debate run

### DIFF
--- a/complete.sh
+++ b/complete.sh
@@ -5,6 +5,13 @@ experiment_name="debate"
 model_name="gpt-4.1-mini-2025-04-14"
 exp_dir="./exp/gpt4_1_mini_15_q_v2"
 
+sandbag=false
+for arg in "$@"; do
+  if [ "$arg" == "--sandbag" ]; then
+    sandbag=true
+  fi
+done
+
 # Debate run
 python -m core.debate \
   exp_dir="$exp_dir" \
@@ -14,7 +21,8 @@ python -m core.debate \
   ++correct_debater.BoN=1 \
   ++incorrect_debater.BoN=1 \
   ++max_num_from_same_story=1 \
-  ++split=train
+  ++split=train \
+  sandbag=$sandbag
 
 # Judge run
 python -m core.judge \

--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -19,6 +19,7 @@ exp_dir: ???
 method: ??? # debate, consultancy
 method_type: ??? # sim, seq | correct, incorrect
 use_intermediary: ???
+sandbag: false
 
 # Load
 seed: 0

--- a/core/create_agents.py
+++ b/core/create_agents.py
@@ -96,6 +96,15 @@ def setup_debate(
 ) -> RolloutBase:
     assert cfg.rollout.name1 != cfg.rollout.name2
 
+    if getattr(cfg, "sandbag", False):
+        sandbag_path = Path(__file__).resolve().parents[1] / "sandbag_prompt.txt"
+        with open(sandbag_path, "r", encoding="utf-8") as f:
+            sandbag_text = f.read().strip()
+        sys_prompt = cfg.correct_debater.prompts.messages[0].content
+        cfg.correct_debater.prompts.messages[0].content = (
+            sandbag_text + "\n" + sys_prompt
+        )
+
     correct_judge_BoN = (
         create_judge(cfg.method, cfg.correct_preference, cfg.rollout, api_handler)
         if cfg.correct_debater.BoN > 1


### PR DESCRIPTION
## Summary
- add `--sandbag` option to complete.sh and pass through to debate
- support sandbag flag in config
- when sandbag is true, prepend sandbag_prompt to correct debater system prompt

## Testing
- `pre-commit run --files complete.sh core/create_agents.py core/config/config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68bc45f0173883329233cb4c1633029c