### PR TITLE
Add configurable team size for debates with optional sandbagging

### DIFF
--- a/complete.sh
+++ b/complete.sh
@@ -6,9 +6,13 @@ model_name="gpt-5-mini-2025-08-07"
 exp_dir="./exp/gpt5_mini_15_q_baseline"
 
 sandbag=false
+num_debaters=2
+
 for arg in "$@"; do
   if [ "$arg" == "--sandbag" ]; then
     sandbag=true
+  elif [[ "$arg" == --num_debaters=* ]]; then
+    num_debaters="${arg#*=}"
   fi
 done
 
@@ -22,7 +26,8 @@ python -m core.debate \
   ++incorrect_debater.BoN=1 \
   ++max_num_from_same_story=1 \
   ++split=train \
-  sandbag=$sandbag
+  sandbag=$sandbag \
+  num_debaters=$num_debaters
 
 # Judge run
 python -m core.judge \

--- a/core/config/config.yaml
+++ b/core/config/config.yaml
@@ -20,6 +20,7 @@ method: ??? # debate, consultancy
 method_type: ??? # sim, seq | correct, incorrect
 use_intermediary: ???
 sandbag: false
+num_debaters: 2
 
 # Load
 seed: 0

--- a/core/create_agents.py
+++ b/core/create_agents.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from omegaconf import DictConfig
 
@@ -60,8 +60,8 @@ def create_rollout(
     method: Method,
     config: RolloutConfig,
     cache_dir: Path,
-    correct_debater: Optional[DebaterBase],
-    incorrect_debater: Optional[DebaterBase],
+    correct_debaters: List[DebaterBase] | DebaterBase | None,
+    incorrect_debaters: List[DebaterBase] | DebaterBase | None,
     cross_examiner: Optional[JudgeBase],
     correct_judge_BoN: Optional[JudgeBase],
     incorrect_judge_BoN: Optional[JudgeBase],
@@ -73,12 +73,27 @@ def create_rollout(
     rollout_class = ROLLOUT_CLASSES.get(config.rollout_type)
     if not rollout_class:
         raise ValueError(f"Unknown rollout type: {config.rollout_type}")
+
+    if correct_debaters is None:
+        correct_list: List[DebaterBase] = []
+    elif isinstance(correct_debaters, list):
+        correct_list = correct_debaters
+    else:
+        correct_list = [correct_debaters]
+
+    if incorrect_debaters is None:
+        incorrect_list: List[DebaterBase] = []
+    elif isinstance(incorrect_debaters, list):
+        incorrect_list = incorrect_debaters
+    else:
+        incorrect_list = [incorrect_debaters]
+
     return rollout_class(
         method,
         config,
         cache_dir,
-        correct_debater,
-        incorrect_debater,
+        correct_list,
+        incorrect_list,
         cross_examiner,
         correct_judge_BoN,
         incorrect_judge_BoN,
@@ -96,14 +111,26 @@ def setup_debate(
 ) -> RolloutBase:
     assert cfg.rollout.name1 != cfg.rollout.name2
 
+    num_debaters = getattr(cfg, "num_debaters", 2)
+    assert num_debaters % 2 == 0, "num_debaters must be even"
+    num_per_side = num_debaters // 2
+
+    import copy
+
+    correct_configs = [copy.deepcopy(cfg.correct_debater) for _ in range(num_per_side)]
+    incorrect_configs = [
+        copy.deepcopy(cfg.incorrect_debater) for _ in range(num_per_side)
+    ]
+
     if getattr(cfg, "sandbag", False):
         sandbag_path = Path(__file__).resolve().parents[1] / "sandbag_prompt.txt"
         with open(sandbag_path, "r", encoding="utf-8") as f:
             sandbag_text = f.read().strip()
-        sys_prompt = cfg.correct_debater.prompts.messages[0].content
-        cfg.correct_debater.prompts.messages[0].content = (
-            sandbag_text + "\n" + sys_prompt
-        )
+        for i, conf in enumerate(correct_configs):
+            if i == 0:
+                continue
+            sys_prompt = conf.prompts.messages[0].content
+            conf.prompts.messages[0].content = sandbag_text + "\n" + sys_prompt
 
     correct_judge_BoN = (
         create_judge(cfg.method, cfg.correct_preference, cfg.rollout, api_handler)
@@ -137,34 +164,29 @@ def setup_debate(
     )
 
     if cfg.method == "debate" or cfg.method == "baseline":
-        correct_debater = create_debater(
-            cfg.method,
-            cfg.correct_debater,
-            correct=True,
-            api_handler=api_handler,
-        )
-        incorrect_debater = create_debater(
-            cfg.method, cfg.incorrect_debater, correct=False, api_handler=api_handler
-        )
+        correct_debaters = [
+            create_debater(cfg.method, conf, correct=True, api_handler=api_handler)
+            for conf in correct_configs
+        ]
+        incorrect_debaters = [
+            create_debater(cfg.method, conf, correct=False, api_handler=api_handler)
+            for conf in incorrect_configs
+        ]
 
     if cfg.method == "consultancy":
         if cfg.method_type == "correct":
-            correct_debater = create_debater(
-                cfg.method,
-                cfg.correct_debater,
-                correct=True,
-                api_handler=api_handler,
-            )
-            incorrect_debater = None
+            correct_debaters = [
+                create_debater(cfg.method, conf, correct=True, api_handler=api_handler)
+                for conf in correct_configs
+            ]
+            incorrect_debaters = []
 
         elif cfg.method_type == "incorrect":
-            correct_debater = None
-            incorrect_debater = create_debater(
-                cfg.method,
-                cfg.incorrect_debater,
-                correct=False,
-                api_handler=api_handler,
-            )
+            correct_debaters = []
+            incorrect_debaters = [
+                create_debater(cfg.method, conf, correct=False, api_handler=api_handler)
+                for conf in incorrect_configs
+            ]
         else:
             raise ValueError(f"Unknown method type: {cfg.method_type}")
 
@@ -182,8 +204,8 @@ def setup_debate(
         cfg.method,
         cfg.rollout,
         cache_dir,
-        correct_debater,
-        incorrect_debater,
+        correct_debaters,
+        incorrect_debaters,
         cross_examiner,
         correct_judge_BoN,
         incorrect_judge_BoN,
@@ -192,9 +214,9 @@ def setup_debate(
         correct_judge_critique_pm,
         incorrect_judge_critique_pm,
     )
-    if correct_debater:
+    if correct_debaters:
         LOGGER.info(cfg.correct_debater.language_model)
-    if incorrect_debater:
+    if incorrect_debaters:
         LOGGER.info(cfg.incorrect_debater.language_model)
     if cross_examiner:
         LOGGER.info(cfg.cross_examiner.language_model)

--- a/core/rollouts/quality_seq.py
+++ b/core/rollouts/quality_seq.py
@@ -18,7 +18,7 @@ class QualitySeqRollout(RolloutBase):
     def __init__(self, *args):
         super().__init__(*args)
         assert (
-            self.correct_debater is not None and self.incorrect_debater is not None
+            self.correct_debaters and self.incorrect_debaters
         ), "Both debaters must be specified"
         assert (
             self.correct_judge_critic is None and self.incorrect_judge_critic is None
@@ -29,13 +29,20 @@ class QualitySeqRollout(RolloutBase):
         transcript: TranscriptConfig,
         current_step: int,
         cache_manager: CacheManager,
+        pair_index: int,
         swap: bool = False,
     ):
         order_name = ["correct", "incorrect"] if not swap else ["incorrect", "correct"]
         order_debater = (
-            [self.correct_debater, self.incorrect_debater]
+            [
+                self.correct_debaters[pair_index],
+                self.incorrect_debaters[pair_index],
+            ]
             if not swap
-            else [self.incorrect_debater, self.correct_debater]
+            else [
+                self.incorrect_debaters[pair_index],
+                self.correct_debaters[pair_index],
+            ]
         )
         order_BoN = (
             [self.correct_judge_BoN, self.incorrect_judge_BoN]
@@ -93,10 +100,10 @@ class QualitySeqRollout(RolloutBase):
             )
         else:
             names["correct"] = (
-                self.config.consultant_name if self.correct_debater else None
+                self.config.consultant_name if self.correct_debaters else None
             )
             names["incorrect"] = (
-                self.config.consultant_name if self.incorrect_debater else None
+                self.config.consultant_name if self.incorrect_debaters else None
             )
             names["cross_examiner"] = (
                 self.config.cross_examiner_name if self.cross_examiner else None
@@ -122,11 +129,15 @@ class QualitySeqRollout(RolloutBase):
             transcript = TranscriptConfig(**json.loads(transcript_cache))
         transcript_string = transcript.json()
 
+        num_pairs = max(len(self.correct_debaters), len(self.incorrect_debaters))
+        total_steps = self.config.num_steps * num_pairs
+
         # Run the debate
-        while current_step < self.config.num_steps:
+        while current_step < total_steps:
             try:
+                pair_idx = current_step % num_pairs
                 transcript = await self.debate_turn(
-                    transcript, current_step, cache_manager, swap
+                    transcript, current_step, cache_manager, pair_idx, swap
                 )
                 current_step += 1
                 transcript_string = transcript.json()
@@ -135,13 +146,16 @@ class QualitySeqRollout(RolloutBase):
                 current_step = -1
                 print(transcript_string)
                 break
-        complete = current_step >= self.config.num_steps
+        complete = current_step >= total_steps
         if complete:
-            debater = (
-                self.correct_debater if self.correct_debater else self.incorrect_debater
+            debaters = (
+                self.correct_debaters
+                if self.correct_debaters
+                else self.incorrect_debaters
             )
             print(f"Completed: {transcript.index}")
-            print(f"Total cost: {debater.api_handler.running_cost:.3f}")
+            total_cost = sum(d.api_handler.running_cost for d in debaters)
+            print(f"Total cost: {total_cost:.3f}")
         return {
             "transcript": transcript_string,
             "complete": complete,

--- a/core/rollouts/quality_sim.py
+++ b/core/rollouts/quality_sim.py
@@ -29,6 +29,7 @@ class QualitySimRollout(RolloutBase):
         transcript: TranscriptConfig,
         current_step: int,
         cache_manager: CacheManager | StubCacheManager,
+        pair_index: int,
         judge_message: Optional[str] = None,
     ):
         new_round = {"type": "sim", "judge": judge_message}
@@ -46,8 +47,8 @@ class QualitySimRollout(RolloutBase):
         transcript.responses.append(Round(**new_responses))
 
         calls = {}
-        if self.correct_debater:
-            calls["correct"] = self.correct_debater.take_turn(
+        if len(self.correct_debaters) > pair_index:
+            calls["correct"] = self.correct_debaters[pair_index].take_turn(
                 transcript,
                 current_step,
                 cache_manager,
@@ -56,8 +57,8 @@ class QualitySimRollout(RolloutBase):
                 self.correct_judge_critique_pm,
             )
 
-        if self.incorrect_debater:
-            calls["incorrect"] = self.incorrect_debater.take_turn(
+        if len(self.incorrect_debaters) > pair_index:
+            calls["incorrect"] = self.incorrect_debaters[pair_index].take_turn(
                 transcript,
                 current_step,
                 cache_manager,
@@ -132,14 +133,18 @@ class QualitySimRollout(RolloutBase):
             transcript = TranscriptConfig(**json.loads(transcript_cache))
         transcript_string = transcript.json()
 
+        num_pairs = max(len(self.correct_debaters), len(self.incorrect_debaters), 1)
+        total_steps = int(self.config.num_steps) * num_pairs
+
         # Run the debate
         duration = 0
-        while current_step < int(self.config.num_steps):
-            if self.correct_debater or self.incorrect_debater or self.cross_examiner:
+        while current_step < total_steps:
+            if self.correct_debaters or self.incorrect_debaters or self.cross_examiner:
                 try:
                     start_time = time.time()
+                    pair_idx = current_step % num_pairs
                     transcript = await self.debate_turn(
-                        transcript, current_step, cache_manager
+                        transcript, current_step, cache_manager, pair_idx
                     )
                     duration = time.time() - start_time
                     LOGGER.info(
@@ -155,17 +160,18 @@ class QualitySimRollout(RolloutBase):
                     break
             else:
                 current_step += 1
-        complete = current_step >= int(self.config.num_steps)
+        complete = current_step >= total_steps
         if complete:
-            if self.correct_debater or self.incorrect_debater:
-                debater = (
-                    self.correct_debater
-                    if self.correct_debater
-                    else self.incorrect_debater
+            if self.correct_debaters or self.incorrect_debaters:
+                debaters = (
+                    self.correct_debaters
+                    if self.correct_debaters
+                    else self.incorrect_debaters
                 )
-                LOGGER.info(f"Total cost: {debater.api_handler.running_cost:.3f}")
+                total_cost = sum(d.api_handler.running_cost for d in debaters)
+                LOGGER.info(f"Total cost: {total_cost:.3f}")
                 # log_model_timings(
-                #     debater.api_handler, save_location="./exp/model_timings.png"
+                #     debaters[0].api_handler, save_location="./exp/model_timings.png"
                 # )
             LOGGER.info(f"Completed: {transcript.index}")
 

--- a/core/rollouts/rollout_base.py
+++ b/core/rollouts/rollout_base.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import pandas as pd
 
@@ -15,8 +15,8 @@ class RolloutBase:
         method: Method,
         config: RolloutConfig,
         cache_dir: Path,
-        correct_debater: Optional[DebaterBase] = None,
-        incorrect_debater: Optional[DebaterBase] = None,
+        correct_debaters: Optional[List[DebaterBase]] = None,
+        incorrect_debaters: Optional[List[DebaterBase]] = None,
         cross_examiner: Optional[JudgeBase] = None,
         correct_judge_BoN: Optional[JudgeBase] = None,
         incorrect_judge_BoN: Optional[JudgeBase] = None,
@@ -28,8 +28,14 @@ class RolloutBase:
         self.method = method
         self.config = config
         self.cache_dir = cache_dir
-        self.correct_debater = correct_debater
-        self.incorrect_debater = incorrect_debater
+        self.correct_debaters = correct_debaters or []
+        self.incorrect_debaters = incorrect_debaters or []
+        self.correct_debater = (
+            self.correct_debaters[0] if self.correct_debaters else None
+        )
+        self.incorrect_debater = (
+            self.incorrect_debaters[0] if self.incorrect_debaters else None
+        )
         self.cross_examiner = cross_examiner
         self.correct_judge_BoN = correct_judge_BoN
         self.incorrect_judge_BoN = incorrect_judge_BoN
@@ -39,7 +45,7 @@ class RolloutBase:
         self.incorrect_judge_critique_pm = incorrect_judge_critique_pm
 
         assert any(
-            [correct_debater, incorrect_debater, cross_examiner]
+            [self.correct_debaters, self.incorrect_debaters, cross_examiner]
         ), "At least one debater must be provided"
 
     async def run(self, index: int, row: pd.Series, swap: bool = False):


### PR DESCRIPTION
## Summary
- allow setting number of debaters via new `num_debaters` option in `complete.sh` and config
- support multiple debaters per side with optional sandbagging for all but one correct debater
- extend rollout logic to iterate across debater pairs

## Testing
- `pre-commit run --files core/config/config.yaml complete.sh core/create_agents.py core/rollouts/rollout_base.py core/rollouts/quality_sim.py core/rollouts/quality_seq.py`
- `python -m core.debate --help`

------
https://chatgpt.com/codex/tasks/task_e_68bc7e208a9083328851d8ade0d9e20d